### PR TITLE
[FIX] Trim the content of the link to remove superfluous spaces

### DIFF
--- a/Classes/Domain/Model/LinkOverride.php
+++ b/Classes/Domain/Model/LinkOverride.php
@@ -77,6 +77,6 @@ class LinkOverride
      */
     public function setContent($content)
     {
-        $this->content = $content;
+        $this->content = trim($content);
     }
 }


### PR DESCRIPTION
The text of the link can have space around it. Remove it with trim on setting it.